### PR TITLE
feat: softmax function with irreducible noise (xi)

### DIFF
--- a/cpm/models/decision.py
+++ b/cpm/models/decision.py
@@ -166,7 +166,7 @@ class SoftmaxIrreducibleNoise:
     >>> activations = np.array([[0.1, 0, 0.2], [-0.6, 0, 0.9]])
     >>> noisy_softmax = SoftmaxIrreducibleNoise(beta=1.5, xi=0.1, activations=activations)
     >>> noisy_softmax.compute()
-
+    array([0.4101454, 0.5898546])
     """
 
     def __init__(self, beta=None, xi=None, activations=None, **kwargs):


### PR DESCRIPTION
This class implements the softmax function with an additional parameter xi, representing "irreducible noise". This function is defined as

(e^(beta * x) / sum(e^(beta * x))) * (1 - xi) + (xi / length(x)),

where beta is the inverse temperature parameter and xi is the irreducible noise parameter.
Thus, if xi = 0, the additional terms cancel out and the function is equal to the standard softmax function.

I've implemented it as a separate class for now, and then we can consider whether to incorporate this into the standard softmax class or not.