### PR TITLE
Experimental/refactor component classes

### DIFF
--- a/cpm/models/decision.py
+++ b/cpm/models/decision.py
@@ -49,6 +49,12 @@ class Softmax:
     By contrast, as beta approaches zero, choices becomes random (i.e., the probabilities the choice options are approximately equal)
     and therefore independent of the options' activations.
 
+    Note that if you have one value for each outcome (i.e. a classical bandit-like problem), and you represent it as a 1D
+    array, you must reshape it in the format specified for activations. So that if you have 3 stimuli
+    which all are actionable, `[0.1, 0.5, 0.22]`, you should have a 2D array of shape (3, 1), `[[0.1], [0.5], [0.22]]`.
+    You can see [Example 2]("./examples/examples2") for a demonstration.
+
+
     Examples
     --------
     >>> from cpm.components.decision import Softmax
@@ -401,7 +407,7 @@ class ChoiceKernel:
 
     See Also
     --------
-    [cpm.components.learning.KernelUpdate](cpm.components.learning.KernelUpdate): A class representing a kernel update (Equation 5; Wilson and Collins, 2019) that updates the kernel values.
+    [cpm.models.learning.KernelUpdate](cpm.components.learning.KernelUpdate): A class representing a kernel update (Equation 5; Wilson and Collins, 2019) that updates the kernel values.
 
     References
     ----------

--- a/cpm/models/learning.py
+++ b/cpm/models/learning.py
@@ -399,7 +399,7 @@ class KernelUpdate:
     ----------
     response : ndarray
         The response vector. It must be a binary numpy.ndarray, so that each element corresponds to a response option. If there are 4 response options, and the second was selected, it would be represented as `[0, 1, 0, 0]`.
-    rate : float
+    alpha : float
         The kernel learning rate.
     kernel : ndarray
         The kernel used for learning. It is a 1D array of kernel values, where each element corresponds to a response option. Each element must correspond to the same response option in the `response` vector.
@@ -408,7 +408,7 @@ class KernelUpdate:
     ----------
     response : ndarray
         The response vector. It must be a binary numpy.ndarray, so that each element corresponds to a response option. If there are 4 response options, and the second was selected, it would be represented as `[0, 1, 0, 0]`.
-    rate : float
+    alpha : float
         The kernel learning rate.
     kernel : ndarray
         The kernel used for learning. It is a 1D array of kernel values, where each element corresponds to a response option. Each element must correspond to the same response option in the `response` vector.
@@ -420,7 +420,7 @@ class KernelUpdate:
 
     See Also
     --------
-    [cpm.components.decision.ChoiceKernel][cpm.components.decision.ChoiceKernel] : A class representing a choice kernel decision policy.
+    [cpm.models.decision.ChoiceKernel][cpm.components.decision.ChoiceKernel] : A class representing a choice kernel decision policy.
 
     References
     ----------


### PR DESCRIPTION
Refactor classes in the decision category.

- Softmax now has a method called `Softmax.irreducible_noise()` which adds noise to softmax output
- fixed documentation in ChoiceKernel (wrong parameter and attribute names in docs)