### PR TITLE
fix: wrong index in core function unpack_participant

### DIFF
--- a/cpm/core/data.py
+++ b/cpm/core/data.py
@@ -69,7 +69,7 @@ def unpack_participants(data, index, keys=None, pandas=True):
     if pandas and keys is not None:
         return data.get_group(keys[index])
     elif pandas and keys is None:
-        return data.iloc[i:, :].squeeze()
+        return data.iloc[index:, :].squeeze()
     else:
         return data[index]
 


### PR DESCRIPTION
- fix indexing in data processing function when it is not a pandas data frame that is being processed